### PR TITLE
fix: rename get_workspace_sidebar_items to get_workspaces

### DIFF
--- a/solvronix_desk/public/js/module_cards.js
+++ b/solvronix_desk/public/js/module_cards.js
@@ -92,7 +92,7 @@
   function fetchWorkspaces(cb) {
     if (_wsCache) { cb(_wsCache); return; }
     frappe.call({
-      method: "frappe.desk.desktop.get_workspace_sidebar_items",
+      method: "frappe.desk.desktop.get_workspaces",
       callback: function (r) {
         if (!r || !r.message) { cb([]); return; }
         var pages = (r.message.pages || []).concat(r.message.private_pages || []);

--- a/solvronix_desk/public/js/solvronix_desk.js
+++ b/solvronix_desk/public/js/solvronix_desk.js
@@ -155,7 +155,7 @@
     if (!$sidebar.length || $sidebar.find("#st-module-switch-btn").length) return;
 
     frappe.call({
-      method: "frappe.desk.desktop.get_workspace_sidebar_items",
+      method: "frappe.desk.desktop.get_workspaces",
       callback: function (r) {
         if (!r.message) return;
         var pages = (r.message.pages || []).concat(r.message.private_pages || []);
@@ -839,7 +839,7 @@
 
     /* Load workspace data */
     frappe.call({
-      method: "frappe.desk.desktop.get_workspace_sidebar_items",
+      method: "frappe.desk.desktop.get_workspaces",
       callback: function (r) {
         if (!r.message) return;
         var pages = (r.message.pages || []).concat(r.message.private_pages || []);


### PR DESCRIPTION
## Problem

Installing Solvronix Desk on Frappe v16 (v16.27.1) causes a ValidationError:

```
frappe.exceptions.ValidationError: Failed to get method for command frappe.desk.desktop.get_workspace_sidebar_items with module 'frappe.desk.desktop' has no attribute 'get_workspace_sidebar_items'
```

## Cause

Frappe v16 PR [#39835](https://github.com/frappe/frappe/pull/39835) renamed `get_workspace_sidebar_items` to `get_workspaces` in `frappe/desk/desktop.py`.

## Fix

Updated all references from `frappe.desk.desktop.get_workspace_sidebar_items` to `frappe.desk.desktop.get_workspaces` in:

- `solvronix_desk/public/js/solvronix_desk.js` (2 occurrences)
- `solvronix_desk/public/js/module_cards.js` (1 occurrence)

## Testing

Verified the fix works on Frappe v16.27.1 with ERPNext v16.28.0 and HRMS v16.13.0.