### PR TITLE
Fix Expense Claim permission error on Today's View

### DIFF
--- a/solvronix_desk/solvronix_desk/page/smart_home/smart_home.js
+++ b/solvronix_desk/solvronix_desk/page/smart_home/smart_home.js
@@ -253,7 +253,7 @@ solvronix_desk.SmartHome = class SmartHome {
 			{ dt: "Sales Invoice",     filters: { status: "Overdue", docstatus: 1 },             label: __("{0} overdue sales invoices"),               route: "/desk/sales-invoice?status=Overdue" },
 			{ dt: "Purchase Order",    filters: { status: "To Receive and Bill", docstatus: 1 },  label: __("{0} pending purchase orders"),              route: "/desk/purchase-order" },
 			{ dt: "Leave Application", filters: { status: "Open", docstatus: 0 },                 label: __("{0} leave applications awaiting approval"),  route: "/desk/leave-application?status=Open" },
-			{ dt: "Expense Claim",     filters: { approval_status: "Draft", docstatus: 0 },       label: __("{0} expense claims pending"),               route: "/desk/expense-claim" },
+			{ dt: "Expense Claim",     filters: { status: "Draft", docstatus: 0 },       label: __("{0} expense claims pending"),               route: "/desk/expense-claim" },
 		].filter(function (c) { return can_read.indexOf(c.dt) !== -1; });
 
 		if (!checks.length) {


### PR DESCRIPTION
## Problem

Today's View queries the restricted Expense Claim approval_status field, causing a PermissionError on Frappe v16.

## Fix

Use the standard status field for draft Expense Claims.

## Tested on

- Frappe 16.28.0
- ERPNext 16.29.0
- HRMS 16.14.0