### PR TITLE
Fix workspace widgets not loading + Today's View routing desync (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.3] — 2026-07-31
+
+### Fixed
+- Workspace dashboard widgets (metric cards/charts) failed to render after navigating Today's View → Home → any workspace, until "Reset Desktop Layout" was performed. The "All Apps" grid (`module_cards.js`) rendered itself via `container.innerHTML =` directly into `.layout-main-section` — the exact DOM node Frappe's `frappe.workspace` singleton owns for its EditorJS instance (`.editor-js-container` / `#editorjs`) across every workspace navigation, Home included. This destroyed those nodes with no teardown; the next workspace's widgets rendered into a re-created but never-reattached, detached editor holder — invisible to the user. The grid now hides (instead of destroys) the real workspace content and restores it when navigating away, so Frappe's singleton is never corrupted. Reported as #7.
+- Browser URL/breadcrumb could get stuck on "Today's View" (`smart-home`) while the actually-rendered page was something else entirely (e.g. a List View), most often right after a full page reload. Our boot-time safety-net redirect read `frappe.get_route()` synchronously inside `$(document).ready`, but Frappe's own router resolves the real route asynchronously — reading it too early could see an empty route and wrongly hijack the URL to `smart-home` while the real page's async render kept going underneath it. The check now runs inside a one-time `frappe.router.on("change", ...)` listener, which only fires once the real route is fully resolved.
+- Clicking the Home icon (to Today's View) could briefly flash the previous workspace's real dashboard content before Today's View settled in. The grid's restore logic re-looked-up the workspace container at restore time, which could still point at the outgoing page if Frappe hadn't finished switching pages yet. It now restores the exact container reference captured when the content was hidden, removing the timing dependency entirely.
+- Navigating to a bare `/desk` URL (e.g. clicking the breadcrumb Home icon) while "Enable Smart Home" is on could leave the URL/route empty while Today's View rendered anyway, with the previous workspace's sidebar stuck on screen. Frappe core silently substitutes an empty page name with `frappe.boot.home_page` at the content level only, without ever updating the route — a split-brain state Frappe's own sidebar logic isn't built to detect, and one that could make our own grid inject into the wrong, stale container. We now turn that silent substitution into a real navigation, so the route, the rendered page, and the sidebar all agree.
+
 ## [1.3.2] — 2026-07-30
 
 ### Fixed

--- a/solvronix_desk/hooks.py
+++ b/solvronix_desk/hooks.py
@@ -6,7 +6,7 @@ app_email = "sales@solvronix.com"
 app_license = "MIT"
 app_color = "#E8610A"
 app_icon = "octicon octicon-paintcan"
-app_version = "1.3.2"
+app_version = "1.3.3"
 
 required_apps = []
 
@@ -28,12 +28,12 @@ app_include_css = [
 app_include_js = [
     "/assets/solvronix_desk/js/dark_mode.js?v=8",
     "/assets/solvronix_desk/js/personalization.js?v=1",
-    "/assets/solvronix_desk/js/solvronix_desk.js?v=38",
+    "/assets/solvronix_desk/js/solvronix_desk.js?v=40",
     "/assets/solvronix_desk/js/sidebar.js?v=3",
     "/assets/solvronix_desk/js/command_palette.js?v=5",
     "/assets/solvronix_desk/js/progressive_forms.js?v=4",
     "/assets/solvronix_desk/js/notification_center.js?v=4",
-    "/assets/solvronix_desk/js/module_cards.js?v=5",
+    "/assets/solvronix_desk/js/module_cards.js?v=8",
 ]
 
 boot_session = "solvronix_desk.boot.add_boot_data"

--- a/solvronix_desk/public/js/module_cards.js
+++ b/solvronix_desk/public/js/module_cards.js
@@ -89,6 +89,15 @@
   /* ── Workspace data cache ────────────────────────────────────── */
   var _wsCache = null;
 
+  /* Cached reference to frappe.workspace's own .layout-main-section —
+     the SAME singleton node for the whole session. Captured the moment
+     we hide its real content; restore uses THIS, never a fresh lookup,
+     so it can't be fooled by frappe.container.page not having swapped
+     over to the new route yet (which caused a visible flash of the old
+     workspace content when navigating away — e.g. clicking the Home
+     icon to Today's View). */
+  var _hiddenContainer = null;
+
   function fetchWorkspaces(cb) {
     if (_wsCache) { cb(_wsCache); return; }
     frappe.call({
@@ -166,13 +175,58 @@
     if (empty) empty.style.display = any ? "none" : "";
   }
 
+  /* ── Hide/restore Frappe's own workspace content ──────────────
+     `container` (.layout-main-section) is the SAME long-lived DOM
+     node Frappe's `frappe.workspace` singleton owns for every
+     workspace, including Home — it creates `.editor-js-container`
+     / `#editorjs` in it once and reuses them for the whole session.
+     We must never destroy those nodes (via innerHTML=) or the
+     EditorJS instance loses its holder and every later workspace
+     silently fails to render (GitHub #7). Hide them instead, and
+     restore on the way out. ────────────────────────────────────── */
+  function hideRealWorkspaceContent(container) {
+    _hiddenContainer = container;
+    var kids = container.children;
+    for (var i = 0; i < kids.length; i++) {
+      var el = kids[i];
+      if (el.id === "st-module-grid") continue;
+      if (el.style.display !== "none") {
+        el.dataset.stHiddenByGrid = "1";
+        el.style.display = "none";
+      }
+    }
+  }
+
+  function restoreRealWorkspaceContent() {
+    var container = _hiddenContainer;
+    if (!container) return;
+    var grid = container.querySelector("#st-module-grid");
+    if (grid) grid.style.display = "none";
+    var hidden = container.querySelectorAll("[data-st-hidden-by-grid]");
+    for (var i = 0; i < hidden.length; i++) {
+      hidden[i].style.display = "";
+      delete hidden[i].dataset.stHiddenByGrid;
+    }
+    _hiddenContainer = null;
+  }
+
   /* ── Render the full module grid into the page ───────────────── */
   function renderGrid(container) {
     if (!container) return;
 
+    hideRealWorkspaceContent(container);
+
+    /* Reuse the grid element across visits instead of rebuilding it */
+    var grid = container.querySelector("#st-module-grid");
+    if (!grid) {
+      grid = document.createElement("div");
+      grid.id = "st-module-grid";
+      container.appendChild(grid);
+    }
+    grid.style.display = "";
+
     /* Grid shell with skeleton loaders */
-    container.innerHTML =
-      '<div id="st-module-grid">' +
+    grid.innerHTML =
       '<div class="st-ws-header">' +
       '<div class="st-ws-title">All Apps</div>' +
       '<div class="st-ws-subtitle">Jump to any workspace from here</div>' +
@@ -180,8 +234,7 @@
       '<div class="st-ws-search-wrap">' +
       '<input id="st-ws-search-input" class="st-ws-search" type="text" placeholder="Search apps…" autocomplete="off">' +
       '</div>' +
-      buildSkeletons(8) +
-      '</div>';
+      buildSkeletons(8);
 
     /* Wire search input */
     var searchInput = document.getElementById("st-ws-search-input");
@@ -252,11 +305,38 @@
     return false;
   }
 
+  /* ── Detect Frappe's silent bare-route content substitution ───
+     frappe.views.pageview.show() (Frappe core) substitutes an empty
+     page name with frappe.boot.home_page — solvronix_desk sets this
+     to "smart-home" when Theme Settings' "Enable Smart Home" is on.
+     That substitution happens at the CONTENT level only: it changes
+     what's rendered (frappe.container.change_to("smart-home")) but
+     never touches frappe.router.current_route, which stays "" — a
+     split-brain state where the route and the visible page disagree.
+     This breaks Frappe's own sidebar resolution (set_workspace_sidebar
+     reads the still-empty route, finds no match, and no-ops — leaving
+     whatever workspace sidebar was showing before stuck on screen) and
+     would make us inject the grid into frappe.container.page, which by
+     then is smart-home's own Page instance, not a Workspace — its
+     .layout-main-section lookup fails and getPageContent()'s unscoped
+     fallback grabs the first matching node anywhere in the DOM, likely
+     a stale hidden one from whatever workspace was active before.
+     Fix at the source: turn the silent substitution into a REAL
+     navigation, so route/content/sidebar all agree on smart-home. */
+  function smartHomeOverrideActive() {
+    return !!(frappe.boot && frappe.boot.home_page);
+  }
+
   /* ── Main injection logic ────────────────────────────────────── */
   function maybeInjectGrid() {
     if (!isHomeRoute()) return;
-    /* Don't re-inject if already rendered */
-    if (document.getElementById("st-module-grid")) return;
+    if (smartHomeOverrideActive()) {
+      frappe.set_route(frappe.boot.home_page);
+      return;
+    }
+    /* Already visible — nothing to do */
+    var existing = document.getElementById("st-module-grid");
+    if (existing && existing.style.display !== "none") return;
 
     /* Wait for the page content div to appear */
     var attempts = 0;
@@ -277,7 +357,21 @@
     /* Hook route change event */
     frappe.router.on("change", function () {
       /* Small delay — let Frappe set up the new page first */
-      setTimeout(function () { maybeInjectGrid(); }, 300);
+      setTimeout(function () {
+        if (isHomeRoute()) {
+          maybeInjectGrid();
+        } else {
+          /* Leaving Home for a real workspace — restore whatever
+             Frappe's own workspace singleton put in this container
+             before the grid hid it, so it renders correctly. Uses the
+             container reference cached at hide time (not a fresh
+             getPageContent() lookup) — frappe.container.page may not
+             have swapped to the new route yet when this fires, which
+             previously caused a visible flash of the old workspace
+             content (e.g. clicking the Home icon to Today's View). */
+          restoreRealWorkspaceContent();
+        }
+      }, 300);
     });
 
     /* Also trigger on first load if already on home */

--- a/solvronix_desk/public/js/solvronix_desk.js
+++ b/solvronix_desk/public/js/solvronix_desk.js
@@ -1114,15 +1114,36 @@
        send the user to Today's View. This does NOT listen on every navigation —
        so sidebar items, workspace links, Desktop page, etc. are never intercepted.
        Frappe's boot.home_page = "smart-home" already handles the normal first-load
-       redirect; this is only a safety net for edge cases (direct URL visits). */
-    (function () {
+       redirect; this is only a safety net for edge cases (direct URL visits).
+
+       frappe.router.route() is async — it only sets frappe.router.current_route
+       (what frappe.get_route() reads) AFTER its internal parse() resolves, which
+       can require an async doctype-meta round trip. Checking synchronously here
+       can run before that first resolution, reading a stale/empty route while
+       core's own routing for the real target is still in flight — hijacking the
+       URL to smart-home while the real page renders underneath it, unrelated to
+       the URL. But we also must not just wait for the next "change" event
+       unconditionally: if core's first route() has ALREADY resolved by the time
+       this runs, current_route is already correct and there's no later "change"
+       coming for THIS load — a bare .once() would sit armed and misfire on
+       whatever the user navigates to next (confirmed live: it fired on a later,
+       unrelated SPA navigation instead of the initial load). So: check directly
+       if current_route is already populated (no race); only if it's genuinely
+       still pending (current_route null — the initial route() hasn't resolved
+       yet) do we wait for the "change" that resolution is guaranteed to fire. */
+    var checkAndRedirectHome = function () {
       var route = (frappe.get_route && frappe.get_route()) || [];
       var isEmptyOrWorkspace = route.length === 0 ||
         (route.length === 1 && (route[0] === "" || route[0] === "workspace"));
       if (isEmptyOrWorkspace) {
         frappe.set_route("smart-home");
       }
-    }());
+    };
+    if (frappe.router && frappe.router.current_route) {
+      checkAndRedirectHome();
+    } else {
+      frappe.router.once("change", checkAndRedirectHome);
+    }
   }
 
   $(document).ready(onDeskReady);


### PR DESCRIPTION
Fixes widgets breaking after Home <-> workspace navigation, a Home-icon
flash, and a URL/sidebar desync on bare /desk with Smart Home enabled.

Fixes #7 