### PR TITLE
Fix theme chrome showing on Setup Wizard (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.4] — 2026-07-31
+
+### Fixed
+- Theme chrome (toolbar, branding, dynamic colors, sidebar extras) rendered on top of Frappe's Setup Wizard during first-run onboarding. `onDeskReady()` ran unconditionally on every desk page load with no check for setup state; it now skips entirely while `frappe.boot.setup_complete` is falsy, so Setup Wizard stays Frappe's clean, standalone flow. Reported as #9.
+
 ## [1.3.3] — 2026-07-31
 
 ### Fixed

--- a/solvronix_desk/hooks.py
+++ b/solvronix_desk/hooks.py
@@ -6,7 +6,7 @@ app_email = "sales@solvronix.com"
 app_license = "MIT"
 app_color = "#E8610A"
 app_icon = "octicon octicon-paintcan"
-app_version = "1.3.3"
+app_version = "1.3.4"
 
 required_apps = []
 
@@ -28,7 +28,7 @@ app_include_css = [
 app_include_js = [
     "/assets/solvronix_desk/js/dark_mode.js?v=8",
     "/assets/solvronix_desk/js/personalization.js?v=1",
-    "/assets/solvronix_desk/js/solvronix_desk.js?v=40",
+    "/assets/solvronix_desk/js/solvronix_desk.js?v=41",
     "/assets/solvronix_desk/js/sidebar.js?v=3",
     "/assets/solvronix_desk/js/command_palette.js?v=5",
     "/assets/solvronix_desk/js/progressive_forms.js?v=4",

--- a/solvronix_desk/public/js/solvronix_desk.js
+++ b/solvronix_desk/public/js/solvronix_desk.js
@@ -1087,6 +1087,10 @@
   }
 
   function onDeskReady() {
+    /* Setup Wizard should stay Frappe's clean, standalone onboarding flow —
+       no theme chrome (toolbar/branding/etc.) until setup actually completes. */
+    if (frappe.boot && !frappe.boot.setup_complete) return;
+
     injectDynamicTheme();
     injectBranding();
     setupTitleUpdate();


### PR DESCRIPTION
Toolbar/branding/theme chrome was rendering on top of Frappe's Setup
Wizard during first-run onboarding. Setup Wizard should stay a clean,
standalone flow with no desk chrome.
Fixes #9 