### PR TITLE
Add Your Apps grid to Today's View, fix broken workspace link (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.4.0] — 2026-07-31 — Today's View Apps Grid
+
+### Added
+- Today's View now shows an "Your Apps" grid right below the KPI cards — the same workspace launcher cards (icons, colors, hover states) as the full "All Apps" grid, so you can jump into any workspace straight from the dashboard instead of navigating elsewhere first. Shows up to 8 workspaces with a "View All Workspaces" link to the full grid. Prompted by #8.
+- New dedicated `/desk/all-apps` page for the full workspace grid. Previously this only lived at the bare `/desk` route, which "Enable Smart Home" redirects away from — meaning the grid (and the "View All Workspaces" link) had no reliable way to be reached on any site with Smart Home on. It now has its own stable route, unaffected by Smart Home or any site's own Workspace naming.
+
 ## [1.3.5] — 2026-07-31
 
 ### Fixed

--- a/solvronix_desk/hooks.py
+++ b/solvronix_desk/hooks.py
@@ -6,7 +6,7 @@ app_email = "sales@solvronix.com"
 app_license = "MIT"
 app_color = "#E8610A"
 app_icon = "octicon octicon-paintcan"
-app_version = "1.3.5"
+app_version = "1.4.0"
 
 required_apps = []
 
@@ -17,7 +17,7 @@ app_include_css = [
     "/assets/solvronix_desk/css/solvronix_desk.css?v=42",
     "/assets/solvronix_desk/css/sidebar.css?v=18",
     "/assets/solvronix_desk/css/command_palette.css?v=4",
-    "/assets/solvronix_desk/css/smart_home.css?v=2",
+    "/assets/solvronix_desk/css/smart_home.css?v=3",
     "/assets/solvronix_desk/css/progressive_forms.css?v=3",
     "/assets/solvronix_desk/css/notification_center.css?v=3",
     "/assets/solvronix_desk/css/polish.css?v=2",
@@ -33,7 +33,7 @@ app_include_js = [
     "/assets/solvronix_desk/js/command_palette.js?v=5",
     "/assets/solvronix_desk/js/progressive_forms.js?v=4",
     "/assets/solvronix_desk/js/notification_center.js?v=4",
-    "/assets/solvronix_desk/js/module_cards.js?v=8",
+    "/assets/solvronix_desk/js/module_cards.js?v=9",
 ]
 
 boot_session = "solvronix_desk.boot.add_boot_data"

--- a/solvronix_desk/public/css/smart_home.css
+++ b/solvronix_desk/public/css/smart_home.css
@@ -110,6 +110,29 @@
   margin-top: 4px;
 }
 
+/* ── Apps grid — cards themselves reuse .st-ws-card from
+   module_cards.css so this matches the full "All Apps" grid exactly;
+   only the section wrapper/heading below is specific to this page. */
+.st-sh-apps-section {
+  margin-bottom: 28px;
+}
+
+.st-sh-apps-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.st-sh-apps-head .st-sh-card-head {
+  padding: 0;
+  border-bottom: none;
+}
+
+.st-sh-apps-head .st-sh-all-ws {
+  margin-top: 0;
+}
+
 /* ── Layout ──────────────────────────────────────────────────── */
 .st-sh-layout {
   display: grid;

--- a/solvronix_desk/public/js/module_cards.js
+++ b/solvronix_desk/public/js/module_cards.js
@@ -377,4 +377,14 @@
     /* Also trigger on first load if already on home */
     setTimeout(function () { maybeInjectGrid(); }, 500);
   });
+
+  /* ── Shared with other theme pages (e.g. Today's View's own apps
+     section) so they render workspace cards identically instead of
+     duplicating the icon/color map and card markup. ─────────────── */
+  frappe.provide("solvronix_desk");
+  solvronix_desk.workspaceCards = {
+    fetchWorkspaces: fetchWorkspaces,
+    buildCard: buildCard,
+    buildSkeletons: buildSkeletons,
+  };
 }());

--- a/solvronix_desk/solvronix_desk/page/all_apps/all_apps.html
+++ b/solvronix_desk/solvronix_desk/page/all_apps/all_apps.html
@@ -1,0 +1,1 @@
+<!-- solvronix-desk: all apps page marker — keeps _dynamic_page=True so localStorage is bypassed -->

--- a/solvronix_desk/solvronix_desk/page/all_apps/all_apps.js
+++ b/solvronix_desk/solvronix_desk/page/all_apps/all_apps.js
@@ -1,0 +1,100 @@
+/* ================================================================
+   Solvronix Desk — All Apps
+   Stable, dedicated route for the workspace launcher grid.
+   Registered as Frappe Page "all-apps" so it always works regardless
+   of Smart Home's bare-route redirect or any site's own Workspace
+   naming (both can make the grid unreachable otherwise — see #8
+   follow-up). Reuses module_cards.js's own card renderer via
+   solvronix_desk.workspaceCards so this looks identical to Today's
+   View's "Your Apps" section and the bare-route grid.
+   ================================================================ */
+
+frappe.pages["all-apps"].on_page_load = function (wrapper) {
+	frappe.ui.make_app_page({
+		parent: wrapper,
+		title: __("All Apps"),
+		single_column: true,
+	});
+	var inst = new solvronix_desk.AllApps(wrapper);
+	frappe.pages["all-apps"]._inst = inst;
+	inst.render();
+};
+
+frappe.provide("solvronix_desk");
+
+solvronix_desk.AllApps = class AllApps {
+	constructor(wrapper) {
+		this.wrapper = $(wrapper);
+		this.$body = this.wrapper.find(".page-content");
+	}
+
+	render() {
+		var wc = solvronix_desk.workspaceCards;
+		if (!wc) {
+			this.$body.html('<div class="st-ws-empty">' + __("Workspace data unavailable.") + "</div>");
+			return;
+		}
+
+		this.$body.html(
+			/* Reuses #st-module-grid's own padding/max-width/dark-mode/
+			   responsive rules from module_cards.css — same spacing as
+			   the original bare-route grid, no duplicated CSS needed. */
+			'<div id="st-module-grid">' +
+			  '<div class="st-ws-header">' +
+			    '<div class="st-ws-title">' + __("All Apps") + '</div>' +
+			    '<div class="st-ws-subtitle">' + __("Jump to any workspace from here") + '</div>' +
+			  '</div>' +
+			  '<div class="st-ws-search-wrap">' +
+			    '<input id="st-all-apps-search" class="st-ws-search" type="text" placeholder="' + __("Search apps…") + '" autocomplete="off">' +
+			  '</div>' +
+			  '<div id="st-all-apps-cards">' + wc.buildSkeletons(8) + '</div>' +
+			'</div>'
+		);
+
+		var $search = this.$body.find("#st-all-apps-search");
+		$search.on("input", this._filter.bind(this));
+
+		wc.fetchWorkspaces(
+			function (pages) {
+				var $cards = this.$body.find("#st-all-apps-cards");
+				if (!pages || !pages.length) {
+					$cards.html('<div class="st-ws-cards"><div class="st-ws-empty">' + __("No workspaces found.") + "</div></div>");
+					return;
+				}
+
+				var html = '<div class="st-ws-cards">' +
+					pages.map(function (p, idx) { return wc.buildCard(p, idx); }).join("") +
+					'<div id="st-all-apps-empty" class="st-ws-empty" style="display:none">' + __("No apps match your search.") + "</div>" +
+				"</div>";
+				$cards.html(html);
+
+				$cards.find(".st-ws-card[data-ws]").each(function () {
+					var slug = this.getAttribute("data-ws");
+					this.addEventListener("click", function (e) {
+						e.preventDefault();
+						if (slug) frappe.set_route(slug);
+					});
+				});
+
+				if ($search.val()) this._filter();
+			}.bind(this)
+		);
+	}
+
+	_filter() {
+		var q = (this.$body.find("#st-all-apps-search").val() || "").toLowerCase().trim();
+		var $cards = this.$body.find("#st-all-apps-cards .st-ws-card");
+		var any = false;
+
+		$cards.each(function () {
+			var $c = $(this);
+			var title = ($c.find(".st-ws-card-name").text() || "").toLowerCase();
+			var desc = ($c.find(".st-ws-card-desc").text() || "").toLowerCase();
+			var match = !q || title.indexOf(q) !== -1 || desc.indexOf(q) !== -1;
+			$c.toggle(match);
+			if (match) any = true;
+		});
+
+		this.$body.find("#st-all-apps-empty").toggle(!any);
+	}
+};

--- a/solvronix_desk/solvronix_desk/page/all_apps/all_apps.json
+++ b/solvronix_desk/solvronix_desk/page/all_apps/all_apps.json
@@ -1,0 +1,10 @@
+{
+ "doctype": "Page",
+ "name": "all-apps",
+ "page_name": "all-apps",
+ "title": "All Apps",
+ "standard": "Yes",
+ "system_page": 0,
+ "module": "Solvronix Desk",
+ "roles": []
+}

--- a/solvronix_desk/solvronix_desk/page/smart_home/smart_home.js
+++ b/solvronix_desk/solvronix_desk/page/smart_home/smart_home.js
@@ -60,10 +60,17 @@ solvronix_desk.SmartHome = class SmartHome {
 			      '<h2 class="st-sh-greeting">' + greeting + ', <span class="st-sh-name">' + this._esc(fname) + '</span></h2>' +
 			      '<div class="st-sh-date">' + date_label + '</div>' +
 			    '</div>' +
-			    '<a href="/desk/home" class="st-sh-all-ws">' + __("All Workspaces") + ' &rarr;</a>' +
 			  '</div>' +
 
 			  '<div class="st-sh-kpi-row" id="st-sh-kpis"></div>' +
+
+			  '<div class="st-sh-apps-section">' +
+			    '<div class="st-sh-apps-head">' +
+			      '<div class="st-sh-card-head">' + __("Your Apps") + '</div>' +
+			      '<a href="/desk/all-apps" class="st-sh-all-ws">' + __("View All Workspaces") + ' &rarr;</a>' +
+			    '</div>' +
+			    '<div id="st-sh-apps" class="st-ws-cards"></div>' +
+			  '</div>' +
 
 			  '<div class="st-sh-layout">' +
 			    '<div class="st-sh-main">' +
@@ -91,6 +98,8 @@ solvronix_desk.SmartHome = class SmartHome {
 		this._build_kpi_shells();
 		/* Quick Create is static — render once, never needs refresh */
 		this._render_quick_create();
+		/* Apps grid — workspace list rarely changes mid-session, render once */
+		this._render_apps_grid();
 	}
 
 	/* ── First full load ───────────────────────────────────────── */
@@ -242,6 +251,38 @@ solvronix_desk.SmartHome = class SmartHome {
 				'<span>' + __(dt) + '</span>' +
 			'</a>';
 		}).join(""));
+	}
+
+	/* ── Apps grid — reuses module_cards.js's own card renderer so
+	     this looks identical to the full "All Apps" grid (same icons,
+	     colors, hover states, dark mode) instead of a second, slightly
+	     different-looking app launcher. ─────────────────────────────── */
+	_render_apps_grid() {
+		var $row = this.$body.find("#st-sh-apps");
+		var wc = solvronix_desk.workspaceCards;
+		if (!wc) return; /* module_cards.js not loaded — nothing to render */
+
+		$row.html(wc.buildSkeletons(8));
+
+		wc.fetchWorkspaces(function (pages) {
+			var items = (pages || []).slice(0, 8);
+			if (!items.length) {
+				$row.html('<div class="st-sh-empty">' + __("No workspaces found.") + '</div>');
+				return;
+			}
+
+			$row.html(items.map(function (p, idx) { return wc.buildCard(p, idx); }).join(""));
+
+			/* buildCard() only returns markup — wire navigation ourselves,
+			   same as module_cards.js's own renderGrid() does. */
+			$row.find(".st-ws-card[data-ws]").each(function () {
+				var slug = this.getAttribute("data-ws");
+				this.addEventListener("click", function (e) {
+					e.preventDefault();
+					if (slug) frappe.set_route(slug);
+				});
+			});
+		});
 	}
 
 	/* ── Pending / Needs Attention ──────────────────────────────── */


### PR DESCRIPTION
**Summary**

- Adds a "Your Apps" grid to Today's View (same cards as the full "All Apps" grid).

Adds a dedicated /desk/all-apps page — fixes the "View All Workspaces" link, which was broken on any site with Smart Home enabled.

**Deployment note**

Adds a new Page doctype. Run bench migrate after pulling, not just a rebuild.

**Tested**

Grid + new page render correctly, click navigation works, no regression on installs without Smart Home, mobile and dark mode both checked.